### PR TITLE
Refactor. API 요청 로직 분리 및 구현

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -1,21 +1,29 @@
 import React from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, Navigate } from "react-router-dom";
 
-import Message from "../components/Message";
 import MainPage from "../components/LandingPage/MainPage";
-import CarouselContainer from "../components/startPointSelectionPage/CarouselContainer";
-import { VERIFICATION_MESSAGE } from "../constants/message";
+import CarouselContainer from "../components/StartPointSelectionPage/CarouselContainer";
+import EditingPage from "../components/ProcessingPage/EditingPage";
+
+import { useYouTubeUrlStore } from "../store";
+// TODO: 필요시 반드시 메인 영상 sub1영상은 입력해야합니다 라는 창을 나타내는 로직을 추가합니다.
 
 function App() {
+  const { youtubeUrls } = useYouTubeUrlStore();
+
+  const hasYoutubeUrls =
+    youtubeUrls.mainYoutubeUrl && youtubeUrls.subOneYoutubeUrl;
+
   return (
     <Routes>
       <Route path="/" element={<MainPage />}></Route>
-      <Route path="/selection" element={<CarouselContainer />}>
-        <Route
-          path="/selection/verification"
-          element={<Message messageType={VERIFICATION_MESSAGE} />}
-        ></Route>
-      </Route>
+      <Route
+        path="/selection"
+        element={
+          hasYoutubeUrls ? <CarouselContainer /> : <Navigate to="/" replace />
+        }
+      ></Route>
+      <Route path="/editing" element={<EditingPage />}></Route>
     </Routes>
   );
 }

--- a/src/components/Message/index.jsx
+++ b/src/components/Message/index.jsx
@@ -1,81 +1,63 @@
-import { useState } from "react";
-
-import axios from "axios";
 import PropTypes from "prop-types";
-import { useNavigate } from "react-router-dom";
 
-import API from "../../../config";
 import Modal from "../shared/Modal";
-import Loading from "../shared/Loading";
-import { VERIFICATION_MESSAGE } from "../../constants/message";
+import { useStartPointStore, useAwsVideoStore } from "../../store";
 import {
-  useAwsVideoStore,
-  useAwsAudioStore,
-  useStartPointStore,
-  useYouTubeUrlStore,
-} from "../../store";
+  AUDIO_ALERT,
+  PLAYTIME_ALERT,
+  PROCEED_MESSAGE,
+} from "../../constants/message";
 
-function Message({ messageType }) {
-  const navigate = useNavigate();
-  const [isLoading, setIsLoading] = useState(false);
-  const { startPoints } = useStartPointStore();
-  const { youtubeUrls } = useYouTubeUrlStore();
-  const { setVideoUrls } = useAwsVideoStore();
-  const { setAudioUrls } = useAwsAudioStore();
+function Message({ messageType, handleProceedClick, handleSelectionClick }) {
+  const { startPoints } = useStartPointStore.getState();
+  const { videoUrls } = useAwsVideoStore.getState();
+  const { HEADER, BODY, FOOTER } = messageType;
 
-  async function handleProcessClick() {
-    if (messageType === VERIFICATION_MESSAGE) {
-      const response = await axios.post(API.COMPILATIONS, { startPoints });
-      // To Do resopnse 받으면 영상 다운 받을 수 있게 처리
-      return;
-    }
+  const isProceedDisabled =
+    messageType === AUDIO_ALERT || messageType === PLAYTIME_ALERT;
 
-    setIsLoading(true);
+  const startPointMessageBody = `Main video: +${startPoints.mainStartPoint} sec,
+    \nSub video 1: +${startPoints.subOneStartPoint} sec,
+    ${
+      videoUrls.subTwoVideoUrl
+        ? `\nSub video 2: +${startPoints.subTwoStartPoint} sec`
+        : ""
+    }`;
 
-    const response = await axios.post(API.CONTENTS, {
-      videoUrls: youtubeUrls,
-      isPermitted: true,
-    });
-
-    const { result } = response.data;
-
-    if (result === "success") {
-      const [mainVideoUrl, subOneVideoUrl, subTwoVideoUrl] =
-        response.data.videoUrlList;
-      const [mainAudioUrl, subOneAudioUrl, subTwoAudioUrl] =
-        response.data.audioUrlList;
-
-      setVideoUrls(mainVideoUrl, subOneVideoUrl, subTwoVideoUrl);
-      setAudioUrls(mainAudioUrl, subOneAudioUrl, subTwoAudioUrl);
-      setIsLoading(false);
-      navigate("/selection");
-    }
+  if (messageType === PROCEED_MESSAGE) {
+    PROCEED_MESSAGE.BODY = startPointMessageBody;
   }
 
   return (
     <>
+      {console.log(isProceedDisabled)}
       <Modal>
-        <section className="z-50 flex flex-col items-center py-20 text-xl text-center px-25 gap-15 rounded-3xl bg-pink">
-          <p className="text-2xl font-bold">{messageType.HEADER}</p>
-          <p>{messageType.BODY}</p>
-          <p>{messageType.FOOTER}</p>
-          <div className="flex justify-around w-full mt-5 text-base">
+        <main className="modal-wrapper">
+          <section className="space-y-20 text-white">
+            <p className="font-bold text-25">{HEADER}</p>
+            <div className="space-y-5">
+              <p className="font-thin text-20">{BODY}</p>
+              <p className="font-thin text-20">{FOOTER}</p>
+            </div>
+          </section>
+          <section className="flex mt-5 font-bold space-x-30 jw-full">
             <button
-              className="px-10 py-5 rounded-3xl bg-purple"
-              onClick={() => navigate(-1)}
+              className="button-selection"
+              onClick={() => handleSelectionClick(null)}
             >
               Go to Selection
             </button>
-            <button
-              className="px-10 py-5 rounded-3xl bg-mint"
-              onClick={handleProcessClick}
-            >
-              Yes, proceed
-            </button>
-          </div>
-        </section>
+            {!isProceedDisabled && (
+              <button
+                className="button-submission"
+                onClick={handleProceedClick}
+              >
+                Yes, proceed
+              </button>
+            )}
+          </section>
+        </main>
       </Modal>
-      {isLoading && <Loading />}
     </>
   );
 }

--- a/src/components/startPointSelectionPage/StartPointSubmitButton/index.jsx
+++ b/src/components/startPointSelectionPage/StartPointSubmitButton/index.jsx
@@ -1,16 +1,69 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+
+import axios from "axios";
+
+import Loading from "../../shared/Loading";
+import Message from "../../Message";
+
+import { useStartPointStore } from "../../../store";
+import { AUDIO_ALERT, PROCEED_MESSAGE } from "../../../constants/message";
+import API from "../../../../config";
 
 function StartPointSubmitButton() {
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [messageContent, setMessageContent] = useState(null);
+  const { startPoints } = useStartPointStore();
+
+  function handleNextButtonClick() {
+    setMessageContent(PROCEED_MESSAGE);
+  }
+
+  async function handleProceedClick() {
+    setIsLoading(true);
+    setMessageContent(null);
+
+    try {
+      const response = await axios.post(API.COMPILATIONS, {
+        startPoints,
+        // TODO. 시작점 외 정보가 필요할 시 추가해야합니다.
+      });
+
+      const { result, message } = response.data;
+
+      if (result === "success") {
+        setIsLoading(false);
+        navigate("/editing");
+      }
+
+      if (message === "audio") {
+        setIsLoading(false);
+        setMessageContent(AUDIO_ALERT);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
 
   return (
-    <button
-      type="button"
-      className="text-white bg-purple rounded-lg text-sm px-5 py-2.5 mb-2"
-      onClick={() => navigate("/selection/verification")}
-    >
-      next step
-    </button>
+    <>
+      <button
+        type="button"
+        className="button-submission"
+        onClick={handleNextButtonClick}
+      >
+        next step
+      </button>
+      {isLoading && <Loading />}
+      {messageContent && (
+        <Message
+          messageType={messageContent}
+          handleProceedClick={handleProceedClick}
+          handleSelectionClick={setMessageContent}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/constants/message.js
+++ b/src/constants/message.js
@@ -1,30 +1,47 @@
-const QUALITY_MESSAGE = {
-  HEADER: "No Quality Found Above 720p",
-  BODY: "Some of the URLs you provided don't have qualities above 720p",
-  FOOTER: "Do you want to proceed with low quality?",
-};
-
-const VERIFICATION_MESSAGE = {
-  HEADER: "All Start Points Have Been Selected",
-  BODY: "",
-  FOOTER: "Do you want to proceed KrossCutting?",
-};
-
 const PLAYTIME_ALERT = {
   HEADER: "Video Is Too Long",
   BODY: "Some of the video you provided are too long to proceed Kross-cutting",
   FOOTER: "Please ensure other video URLs have a playtime below 5 minutes",
 };
 
-const START_POINT_ALERT = {
-  HEADER: "Start Point Not Selected",
-  BODY: "The start point of the main video has not been selected",
-  FOOTER: "Please select start point to proceed Kross-cutting",
+const AUDIO_ALERT = {
+  HEADER: "Start points do not match",
+  BODY: "Start points of the selected videos do not match",
+  FOOTER: "Please set the start point of all videos to be the same",
+};
+
+const INVALID_URL_ALERT = {
+  HEADER: "No video found for the submitted URL",
+  BODY: "Some of the submitted URL does not contain a video",
+  FOOTER: "Please verify that all URLs are correct and submit valid ones",
+};
+
+const QUALITY_MESSAGE = {
+  HEADER: "Unable to load 1080hd quality",
+  BODY: "Some of the submitted URLs cannot load videos in 1080hd quality",
+  // TODO: 서버작업의 에러핸들링 완료시 어떤 영상의 화질이 1080hd로 받을 수 없는지 알려줄 수 있도록 합니다.
+  FOOTER: "Would you like to proceed with 720hd for those videos?",
+};
+
+const PROCEED_MESSAGE = {
+  HEADER: "All Start Points Have Been Selected",
+  BODY: "",
+  FOOTER: "Do you want to proceed KrossCutting?",
+};
+
+const PROGRESS_MESSAGE = {
+  AUDIO_EXTRACTING: "Extracting audio files, in progress...",
+  FACE_DETECTION: "Facial detection in progress, please wait a moment...",
+  MOVEMENT_DETECTION: "Motion detection in progress, please wait a moment...",
+  EDITING: "Editing video, please wait...",
+  EXPORTING: "Exporting video, please wait...",
 };
 
 export {
-  QUALITY_MESSAGE,
-  VERIFICATION_MESSAGE,
   PLAYTIME_ALERT,
-  START_POINT_ALERT,
+  AUDIO_ALERT,
+  INVALID_URL_ALERT,
+  QUALITY_MESSAGE,
+  PROCEED_MESSAGE,
+  PROGRESS_MESSAGE,
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -52,9 +52,9 @@ const youtubeUrlStore = (set) => ({
 
 const startPointStore = (set) => ({
   startPoints: {
-    mainStartPoint: undefined,
-    subOneStartPoint: undefined,
-    subTwoStartPoint: undefined,
+    mainStartPoint: null,
+    subOneStartPoint: null,
+    subTwoStartPoint: null,
   },
   setStartPoints: ({ mainStartPoint, subOneStartPoint, subTwoStartPoint }) =>
     set({


### PR DESCRIPTION
# KanBan Title
- [클라이언트 API 요청 관련 리팩토링](https://www.notion.so/minsug/Client-Server-axios-7a1967f30f384a7e87a90f9b9e14e197?pvs=4)
- [리팩토링 리스트](https://www.notion.so/minsug/FE-4c7f8650ce1348719be18b2a9fbcde85?pvs=4) 
   (정리중으로 완료시 해당 문구는 삭제 예정입니다.)

# Tasks in detail - checkList
- [x] 메인영상, 서브1 영상 url 미입력시 페이지 이동 제한 및 필수 입력 추가
- [x] Message 컴포넌트 내의 proceed 버튼 클릭시 API 재요청 로직 삭제 (모달창 유틸화)
- [x] Message 컴포넌트의 API 재요청 로직 해당 컴포넌트에 구현 (요청을 보내는 컴포넌트로 로직 분리)
- [x] Message 컴포넌트의 go to selection 버튼 클릭시 페이지 되돌아가기 로직 수정
- [x] StartPointSubmitButton 클릭시 페이지 이동 로직 수정
- [x] StartPointSubmitButton 클릭시 서버로 API 요청 로직 추가 (API.CONTENTS)

# Description
- 클라이언트에서 서버로 API 요청하는 부분에 대해 리팩토링을 진행하였으며,
   그 외에도 페이지 이동과 관련된 내용 전반에 대해 리팩토링 진행하였습니다.
   
   주요한 리팩토링 사항으로는 Message 컴포넌트에서 API 재요청 로직을 
   각 컴포넌트에 독립적으로 로직 분리 및 구현 진행하였습니다.

   (Message 컴포넌트의 proceed 버튼 클릭시 매번 모든 재요청을 
   메세지 타입별로 Message 컴포넌트에서 분기처리하여 요청을 보내는 로직을 
   재요청이 필요한 해당 컴포넌트 자체에서 보낼 수 있도록 로직 분리 및 props 처리 했습니다)

# remarks
- 서버측의 로직들을 모두 연결한 후에 API.CONTENTS에 대한 서버 연결이 필요합니다. (현재는 클라이언트의 요청 로직만 완성)
- url 입력 여부에 대한 검증은 추가했으나 url에 영상이 존재하는지에 대한 서버의 에러핸들링이 필요합니다.

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다. (권장)
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
