### PR TITLE
Feat. validation 앤드 포인트 분리 및 영상 다운로드 활성화

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ const API = {
   URLS: `${SERVER_URL}/videos/contents/urls`,
   FILES: `${SERVER_URL}/videos/contents/files`,
   COMPILATIONS: `${SERVER_URL}/videos/compilations`,
+  VALIDATIONS: `${SERVER_URL}/validations`,
 };
 
 export default API;

--- a/src/components/Message/index.jsx
+++ b/src/components/Message/index.jsx
@@ -42,8 +42,8 @@ function Message({ messageType, handleProceedClick, handleSelectionClick }) {
         <section className="space-y-20 text-white">
           <div className="text-lg font-bold md:text-25">{HEADER}</div>
           <div className="space-y-5">
-            <span className="text-base font-thin md:text-20">{BODY}</span>
-            <span className="text-base font-thin md:text-20">{FOOTER}</span>
+            <div className="text-base font-thin md:text-20">{BODY}</div>
+            <div className="text-base font-thin md:text-20">{FOOTER}</div>
           </div>
         </section>
         <section className="flex mt-5 space-x-20 font-bold">

--- a/src/components/Message/index.jsx
+++ b/src/components/Message/index.jsx
@@ -42,8 +42,8 @@ function Message({ messageType, handleProceedClick, handleSelectionClick }) {
         <section className="space-y-20 text-white">
           <div className="text-lg font-bold md:text-25">{HEADER}</div>
           <div className="space-y-5">
-            <p className="text-base font-thin md:text-20">{BODY}</p>
-            <p className="text-base font-thin md:text-20">{FOOTER}</p>
+            <span className="text-base font-thin md:text-20">{BODY}</span>
+            <span className="text-base font-thin md:text-20">{FOOTER}</span>
           </div>
         </section>
         <section className="flex mt-5 space-x-20 font-bold">

--- a/src/components/ProcessingPage/DownloadBox/index.jsx
+++ b/src/components/ProcessingPage/DownloadBox/index.jsx
@@ -1,7 +1,9 @@
 import { useNavigate } from "react-router-dom";
+import { useFinalVideoUrlStore } from "../../../store";
 
 function DownloadBox() {
   const navigate = useNavigate();
+  const { finalVideoUrl } = useFinalVideoUrlStore();
 
   function handleHomeButtonClick() {
     navigate("/");
@@ -16,9 +18,12 @@ function DownloadBox() {
         <br /> has been successfully completed!
       </p>
       <div className="flex flex-col items-center justify-center font-bold space-y-30 text-20">
-        <button type="button" className="rounded bg-purple w-130 h-50">
+        <a
+          href={finalVideoUrl}
+          className="flex items-center justify-center rounded bg-purple w-130 h-50"
+        >
           Download
-        </button>
+        </a>
       </div>
       <div className="flex flex-col items-center justify-center text-20">
         <p className="font-thin">Try another Kross-cutting?</p>

--- a/src/components/ProcessingPage/EditingPage/index.jsx
+++ b/src/components/ProcessingPage/EditingPage/index.jsx
@@ -1,14 +1,17 @@
+import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import axios from "axios";
 
-import WhiteLogo from "../../shared/WhiteLogo";
-import VideoBackground from "../../shared/VideoBackground";
 import ProgressBox from "../ProgressBox";
 import ProgressBar from "../ProgressBar";
-import API from "../../../../config";
+import WhiteLogo from "../../shared/WhiteLogo";
+import VideoBackground from "../../shared/VideoBackground";
 
-function useProgressStatus() {
+import API from "../../../../config";
+import { useFinalVideoUrlStore } from "../../../store";
+
+function useProgressStatus(videoStatus) {
   return useQuery({
     queryKey: ["progressStatus"],
     queryFn: async () => {
@@ -18,12 +21,20 @@ function useProgressStatus() {
     },
     // mockup시연의 경우 짧게 설정하고, 이후는 5-10초로 설정합니다.
     refetchInterval: 1000,
+    enabled: videoStatus,
   });
 }
 
 function EditingPage() {
-  const { data, isLoading, isError } = useProgressStatus();
-  // TODO. 서버의 진행상황을 props로 ProgressBox, ProgressBar에 전달해야합니다.
+  const [isCuttingInProgress, setIsCuttingInProgress] = useState(true);
+  const { finalVideoUrl } = useFinalVideoUrlStore();
+  const { data } = useProgressStatus(isCuttingInProgress);
+
+  useEffect(() => {
+    if (finalVideoUrl !== "") {
+      setIsCuttingInProgress(false);
+    }
+  }, [finalVideoUrl]);
 
   return (
     <main className="box-border w-screen h-screen">

--- a/src/components/ProcessingPage/EditingPage/index.jsx
+++ b/src/components/ProcessingPage/EditingPage/index.jsx
@@ -11,7 +11,7 @@ import VideoBackground from "../../shared/VideoBackground";
 import API from "../../../../config";
 import { useFinalVideoUrlStore } from "../../../store";
 
-function useProgressStatus(videoStatus) {
+function useProgressStatus(isEnable) {
   return useQuery({
     queryKey: ["progressStatus"],
     queryFn: async () => {
@@ -21,7 +21,7 @@ function useProgressStatus(videoStatus) {
     },
     // mockup시연의 경우 짧게 설정하고, 이후는 5-10초로 설정합니다.
     refetchInterval: 1000,
-    enabled: videoStatus,
+    enabled: isEnable,
   });
 }
 

--- a/src/components/ProcessingPage/ProgressBar/index.jsx
+++ b/src/components/ProcessingPage/ProgressBar/index.jsx
@@ -36,7 +36,7 @@ function ProgressBar({ progressStatus }) {
 }
 
 ProgressBar.defaultProps = {
-  progressStatus: "frames",
+  progressStatus: "start",
 };
 
 export default ProgressBar;

--- a/src/components/ProcessingPage/ProgressBar/index.jsx
+++ b/src/components/ProcessingPage/ProgressBar/index.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 
 function ProgressBar({ progressStatus }) {
   const [progressWidth, setProgressWidth] = useState(0);
@@ -29,8 +28,8 @@ function ProgressBar({ progressStatus }) {
   );
 }
 
-ProgressBar.propTypes = {
-  progressStatus: PropTypes.string.isRequired,
+ProgressBar.defaultProps = {
+  progressStatus: "frames",
 };
 
 export default ProgressBar;

--- a/src/components/ProcessingPage/ProgressBar/index.jsx
+++ b/src/components/ProcessingPage/ProgressBar/index.jsx
@@ -1,20 +1,27 @@
 import { useState, useEffect } from "react";
+import { useFinalVideoUrlStore } from "../../../store";
 
 function ProgressBar({ progressStatus }) {
   const [progressWidth, setProgressWidth] = useState(0);
+  const { finalVideoUrl } = useFinalVideoUrlStore();
 
   useEffect(() => {
     const stageWidths = {
-      start: 10,
-      audios: 30,
-      frames: 50,
-      editpoints: 70,
-      completed: 100,
+      start: 5,
+      audios: 10,
+      frames: 25,
+      singleShot: 50,
+      editing: 70,
+      exporting: 90,
     };
 
     const currentStageWidth = stageWidths[progressStatus] || 0;
     setProgressWidth(currentStageWidth);
-  }, [progressStatus]);
+
+    if (finalVideoUrl !== "") {
+      setProgressWidth(100);
+    }
+  }, [progressStatus, finalVideoUrl]);
 
   return (
     <div className="bg-[rgba(255,255,255,0.3)] min-w-400 w-[60vw] min-h-30 rounded-lg flex items-center justify-start px-5">

--- a/src/components/ProcessingPage/ProgressBox/index.jsx
+++ b/src/components/ProcessingPage/ProgressBox/index.jsx
@@ -1,14 +1,15 @@
 import { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 
 import DownloadBox from "../DownloadBox";
 import ProgressMessage from "../ProgressMessage";
 import Loading from "../../shared/Loading";
 
+import { useFinalVideoUrlStore } from "../../../store";
 import { PROGRESS_MESSAGE } from "../../../constants/message";
 
 function ProgressBox({ progressStatus }) {
   const [isLoading, setIsLoading] = useState(true);
+  const { finalVideoUrl } = useFinalVideoUrlStore();
   let messageType = "Loading...";
 
   useEffect(() => {
@@ -18,14 +19,6 @@ function ProgressBox({ progressStatus }) {
   }, [progressStatus]);
 
   switch (progressStatus) {
-    case "start":
-      messageType = PROGRESS_MESSAGE.AUDIO_EXTRACTING;
-      break;
-
-    case "audios":
-      messageType = PROGRESS_MESSAGE.AUDIO_EXTRACTING;
-      break;
-
     case "frames":
       messageType = PROGRESS_MESSAGE.FRAME_EXPORTING;
       break;
@@ -43,7 +36,7 @@ function ProgressBox({ progressStatus }) {
   }
 
   const progressContent =
-    messageType === "completed" ? (
+    finalVideoUrl !== "" ? (
       <DownloadBox />
     ) : (
       <ProgressMessage messageContent={messageType} />
@@ -59,8 +52,8 @@ function ProgressBox({ progressStatus }) {
   );
 }
 
-ProgressBox.propTypes = {
-  progressStatus: PropTypes.string.isRequired,
+ProgressBox.defaultProps = {
+  progressStatus: "frames",
 };
 
 export default ProgressBox;

--- a/src/components/ProcessingPage/ProgressBox/index.jsx
+++ b/src/components/ProcessingPage/ProgressBox/index.jsx
@@ -19,16 +19,24 @@ function ProgressBox({ progressStatus }) {
   }, [progressStatus]);
 
   switch (progressStatus) {
+    case "start":
+      messageType = PROGRESS_MESSAGE.START_KROSSCUTTING;
+      break;
+
     case "frames":
       messageType = PROGRESS_MESSAGE.FRAME_EXPORTING;
       break;
 
-    case "editpoints":
+    case "singleShot":
       messageType = PROGRESS_MESSAGE.MOVEMENT_DETECTION;
       break;
 
-    case "completed":
-      messageType = "completed";
+    case "editing":
+      messageType = PROGRESS_MESSAGE.EDITING;
+      break;
+
+    case "exporting":
+      messageType = PROGRESS_MESSAGE.EXPORTING;
       break;
 
     default:
@@ -53,7 +61,7 @@ function ProgressBox({ progressStatus }) {
 }
 
 ProgressBox.defaultProps = {
-  progressStatus: "frames",
+  progressStatus: "start",
 };
 
 export default ProgressBox;

--- a/src/components/StartPointSelectionPage/StartPointSubmitButton/index.jsx
+++ b/src/components/StartPointSelectionPage/StartPointSubmitButton/index.jsx
@@ -32,6 +32,8 @@ function StartPointSubmitButton() {
 
       const { result, message, labelInfo } = response.data;
 
+      // To Do. 추후 배포시 렌더링되는 EditPage로 옮겨할 수 있음
+      // 현재 여기에쓴 이유는 개발자 모드로 useEffect가 두번 발동되기 때문
       if (result === "success") {
         setIsLoading(false);
         navigate("/editing");

--- a/src/constants/message.js
+++ b/src/constants/message.js
@@ -30,6 +30,7 @@ const PROCEED_MESSAGE = {
 };
 
 const PROGRESS_MESSAGE = {
+  START_KROSSCUTTING: "Starting Krosscutting",
   AUDIO_EXTRACTING: "Extracting audio files...",
   FRAME_EXPORTING: "Exporting frames to analyze...",
   MOVEMENT_DETECTION: "Motion detection in progress, please wait a moment...",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -65,14 +65,21 @@ const startPointStore = (set) => ({
     }),
 });
 
+const finalVideoUrlStore = (set) => ({
+  finalVideoUrl: "",
+  setFinalVideoUrl: (finalVideoUrl) => set({ finalVideoUrl }),
+});
+
 const useAwsVideoStore = create(devtools(awsVideoStore));
 const useAwsAudioStore = create(devtools(awsAudioStore));
 const useStartPointStore = create(devtools(startPointStore));
 const useYouTubeUrlStore = create(devtools(youtubeUrlStore));
+const useFinalVideoUrlStore = create(devtools(finalVideoUrlStore));
 
 export {
   useAwsVideoStore,
   useAwsAudioStore,
   useStartPointStore,
   useYouTubeUrlStore,
+  useFinalVideoUrlStore,
 };


### PR DESCRIPTION
# KanBan Title
- [앤드포인트 분리](https://minsug.notion.site/Server-751ffa1efe8444a68fee545c19231a21?pvs=4)

# Tasks in detail - checkList
- [x] 서버 요청을 validations과 compilations로 분리
- [x] 서버에서 전달받은 finalVideoUrl을 전역 상태로 저장 

# Description
- 유저에게 진척상황을 알리기 위해 엔드포인트를 분리하였습니다. 기존에는 하나의 앤드포인트에서 오디오 유효성 검사부터 최종 영상까지 작업했지만 이제 validationa이라는 엔드포인트를 통해 유효성 검사 후 편집을 시작합니다.
- 유저에게 완성된 영상을 다운로드 받을 수 있게 전달받은 s3 url을 이용했습니다.

# Concern
- 서버 요청을 렌더링되는 진척바 페이지에서 하는 것이 아니라 기존 요청을 보냈던 곳에서 다시 보낸 후 응답을 전역 상태로 처리했습니다. 
- 이와 같이 코드를 설계한 이유는 랜더링되는 페이지에서 useEffect를 사용할 시 개발자 모드상태에서 서버 요청이 두번 들어가게 되어 변경했습니다. 만약 실제 배포할때는 useEffect를 사용할지 아니면 이대로 쭉 사용할지 고민이되는데 한번 봐주시면 감사하겠습니다.
- 진척바가 끝까지 채워지지 않는 현상이 있습니다 추후 작업이 필요합니다.

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
